### PR TITLE
Fix global vars in LZWEncoder

### DIFF
--- a/lib/LZWEncoder.js
+++ b/lib/LZWEncoder.js
@@ -38,6 +38,9 @@ function LZWEncoder(width, height, pixels, colorDepth) {
   var a_count;
   var free_ent = 0; // first unused entry
   var maxcode;
+  var remaining;
+  var curPixel;
+  var n_bits;
 
   // block compression parameters -- after all codes are used up,
   // and compression rate changes, start over.


### PR DESCRIPTION
**Bug**
A few vars in LZWEncoder are globals, preventing strict mode from working.

I was trying to use this library with Babel/webpack, which automatically tacks on "use strict".

**Fix**
Scope the 3 offending vars to the `LZWEncoder` class instead, which seems like the original intent.